### PR TITLE
Fix for SecurityError when running npm run test

### DIFF
--- a/lib/captcha.test.js
+++ b/lib/captcha.test.js
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment node
+ */
 const captcha = require('./index')
 
 describe('inverse captcha', () => {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
     "prettier": "^1.11.1",
     "jest": "^22.4.3"
   },
-  "dependencies": {
+  "dependencies": {},
+  "jest": {
+    "verbose": true,
+    "testURL": "http://localhost/"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,9 +17,5 @@
     "prettier": "^1.11.1",
     "jest": "^22.4.3"
   },
-  "dependencies": {},
-  "jest": {
-    "verbose": true,
-    "testURL": "http://localhost/"
-  }
+  "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -17,5 +17,6 @@
     "prettier": "^1.11.1",
     "jest": "^22.4.3"
   },
-  "dependencies": {}
+  "dependencies": {
+  }
 }


### PR DESCRIPTION
Hi. When I run `npm run test` it gives this error:

```
 FAIL  lib/captcha.test.js
  ● Test suite failed to run

    SecurityError: localStorage is not available for opaque origins
```

This addition - [as suggested here](https://github.com/jsdom/jsdom/issues/2304#issuecomment-440985532) - fixes it for me!